### PR TITLE
fix dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   gtag('config', 'UA-164614767-1');
 </script>
 
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core"></script>
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter"></script>
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/facemesh"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@1.7.3"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-converter@1.7.3"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/facemesh@0.0.3"></script>
 
 <script>
 function load_video() {


### PR DESCRIPTION
This demo had stopped working because the latest versions of tf.js and facemesh were being imported. The most recent versions of these packages are not compatible with the original ones used when writing this code. This PR pins to the original versions used.